### PR TITLE
Update JBSpacerOption to accept itemSize as CGSize and use both width an...

### DIFF
--- a/JBSpacer.podspec
+++ b/JBSpacer.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = 'Mike Swanson'
   s.platform     = :ios, '6.0'
-  s.source       = { :git => "https://github.com/mikeswanson/JBSpacer.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/AJMiller/JBSpacer.git", :tag => s.version.to_s }
   s.source_files = 'JBSpacer/JBSpacer.{h,m}', 'JBSpacer/JBSpacerOption.{h,m}'
   s.requires_arc = true
 

--- a/JBSpacer/JBSpacer.m
+++ b/JBSpacer/JBSpacer.m
@@ -181,11 +181,11 @@ CGFloat JBSnapFloatToScale(CGFloat value, CGFloat scale)
     
     _spacing = JBSpacingZero;
     
-    if (!_option || _option.itemSize == 0.0f || _option.availableSize == 0.0f) { return; }
+    if (!_option || _option.itemSize.width == 0.0f || _option.availableSize == 0.0f) { return; }
     
     CGFloat minimumMargin = _option.minimumGutter * _option.gutterToMarginRatio;
     CGFloat maximumContentWidth = _option.availableSize - (minimumMargin * 2.0f);
-    NSUInteger itemCount = (maximumContentWidth / _option.itemSize);
+    NSUInteger itemCount = (maximumContentWidth / _option.itemSize.width);
     CGFloat neededContentWidth = FLT_MAX;
     
     // Any items to consider?
@@ -195,7 +195,7 @@ CGFloat JBSnapFloatToScale(CGFloat value, CGFloat scale)
         while (itemCount > 0 &&
                neededContentWidth > maximumContentWidth) {
             
-            neededContentWidth = (itemCount * _option.itemSize) + ((itemCount - 1) * _option.minimumGutter);
+            neededContentWidth = (itemCount * _option.itemSize.width) + ((itemCount - 1) * _option.minimumGutter);
             
             itemCount--;
         };
@@ -205,7 +205,7 @@ CGFloat JBSnapFloatToScale(CGFloat value, CGFloat scale)
             
             _spacing.itemCount = itemCount + 1;
             
-            CGFloat idealGutter = ((_option.availableSize - (_spacing.itemCount * _option.itemSize)) /
+            CGFloat idealGutter = ((_option.availableSize - (_spacing.itemCount * _option.itemSize.width)) /
                                    (_spacing.itemCount + (2.0f * _option.gutterToMarginRatio) - 1.0f));
             
             // Snap values to screen scale
@@ -214,7 +214,7 @@ CGFloat JBSnapFloatToScale(CGFloat value, CGFloat scale)
             _spacing.gutter = JBSnapFloatToScale(idealGutter, screenScale);
             
             _spacing.extra = (_option.availableSize -
-                              ((_spacing.margin * 2.0f) + (_spacing.itemCount * _option.itemSize) + ((_spacing.itemCount - 1) * _spacing.gutter)));
+                              ((_spacing.margin * 2.0f) + (_spacing.itemCount * _option.itemSize.width) + ((_spacing.itemCount - 1) * _spacing.gutter)));
             
             // Distribute extra to the margins?
             if (_option.distributeExtraToMargins &&
@@ -286,14 +286,14 @@ CGFloat JBSnapFloatToScale(CGFloat value, CGFloat scale)
     NSUInteger column = index % self.spacing.itemCount;
     
     CGFloat screenScale = (_screenScale == 0.0f ? [UIScreen mainScreen].scale : _screenScale);
-    CGFloat x = JBSnapFloatToScale(self.spacing.margin + (column * self.option.itemSize) + (column * self.spacing.gutter), screenScale);
-    CGFloat y = JBSnapFloatToScale(self.spacing.margin + (row * self.option.itemSize) + (row * self.spacing.gutter), screenScale);
+    CGFloat x = JBSnapFloatToScale(self.spacing.margin + (column * self.option.itemSize.width) + (column * self.spacing.gutter), screenScale);
+    CGFloat y = JBSnapFloatToScale(self.spacing.margin + (row * self.option.itemSize.height) + (row * self.spacing.gutter), screenScale);
     
     // Lower precision
     x = JBSnapFloatToScale(x, JBLowPrecisionScale);
     y = JBSnapFloatToScale(y, JBLowPrecisionScale);
     
-    return CGRectMake(x, y, self.option.itemSize, self.option.itemSize);
+    return CGRectMake(x, y, self.option.itemSize.width, self.option.itemSize.height);
 }
 
 - (void)applySpacingToCollectionViewFlowLayout:(UICollectionViewFlowLayout *)flowLayout
@@ -307,7 +307,7 @@ CGFloat JBSnapFloatToScale(CGFloat value, CGFloat scale)
     
     flowLayout.minimumLineSpacing = gutter;
     flowLayout.minimumInteritemSpacing = gutter;
-    flowLayout.itemSize = CGSizeMake(self.option.itemSize, self.option.itemSize);
+    flowLayout.itemSize = CGSizeMake(self.option.itemSize.width, self.option.itemSize.height);
     flowLayout.sectionInset = UIEdgeInsetsMake(margin, margin, margin, marginExtra);    // Apply extra to right margin
 }
 

--- a/JBSpacer/JBSpacerOption.h
+++ b/JBSpacer/JBSpacerOption.h
@@ -39,7 +39,7 @@
 #pragma mark - Properties
 
 /** The size of each item (in points). */
-@property (nonatomic, readwrite, assign)    CGFloat         itemSize;
+@property (nonatomic, readwrite, assign)    CGSize         itemSize;
 
 /** The minimum spacing to use between items (in points). */
 @property (nonatomic, readwrite, assign)    CGFloat         minimumGutter;
@@ -71,7 +71,7 @@
  *
  *  @return                             New spacer option with the specified settings.
  */
-+ (JBSpacerOption *)optionWithItemSize:(CGFloat)itemSize
++ (JBSpacerOption *)optionWithItemSize:(CGSize)itemSize
                          minimumGutter:(CGFloat)minimumGutter
                    gutterToMarginRatio:(CGFloat)gutterToMarginRatio
                          availableSize:(CGFloat)availableSize

--- a/JBSpacer/JBSpacerOption.m
+++ b/JBSpacer/JBSpacerOption.m
@@ -33,7 +33,7 @@
 
 #pragma mark - Class methods
 
-+ (JBSpacerOption *)optionWithItemSize:(CGFloat)itemSize
++ (JBSpacerOption *)optionWithItemSize:(CGSize)itemSize
                          minimumGutter:(CGFloat)minimumGutter
                    gutterToMarginRatio:(CGFloat)gutterToMarginRatio
                          availableSize:(CGFloat)availableSize
@@ -57,7 +57,7 @@
     self = [super init];
     if (self) {
         
-        _itemSize = 0.0f;
+        _itemSize = CGSizeMake(0.0f, 0.0f);
         _minimumGutter = 0.0f;
         _gutterToMarginRatio = 0.0f;
         _availableSize = 0.0f;
@@ -68,11 +68,11 @@
 
 #pragma mark - Properties
 
-- (void)setItemSize:(CGFloat)itemSize
+- (void)setItemSize:(CGSize)itemSize
 {
-    NSCParameterAssert(itemSize >= 0.0f);
+    NSCParameterAssert(itemSize.width >= 0.0f);
     
-    if (itemSize != _itemSize) {
+    if (itemSize.width != _itemSize.width) {
         
         _itemSize = itemSize;
     }


### PR DESCRIPTION
This pull request updates the JBSpacer class to accept a CGSize struct instead of a CGFloat. It still bases updates on the .width of the CGSize, but also honors any .height passed in.
